### PR TITLE
Clean up jekyll site, archive that, then merge with Dana's Nov 15 MVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Nation of Makers</title>
     <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>
+    <meta charset="UTF-8">
     <link href='https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css' rel='stylesheet'>
     <link href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
     <link href='https://fonts.googleapis.com/css?family=Crimson+Text|Open+Sans:400,700' rel='stylesheet'>


### PR DESCRIPTION
HOLD, DO NOT ACCEPT:  This will duplicate history.  I'm working on a rebase right now.  

This PR is a rollup of the last 20 hours' work:  I'm committing the jekyll site cleanup I did yesterday so we have that archived, then merging with Dana's HTML/CSS MVP site for Nov 15, which deletes the jekyll bits entirely.

The most recent commit builds on Dana's MVP, adding the utf-8 meta tag to fix glyphs in some browsers.

A preview of the resulting site is visible at https://stevegt.github.io/nationofmakers.github.io/