### PR TITLE
Prevent horizontal scrolling on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,9 @@ p {
   letter-spacing: 0.3rem;
   text-transform: uppercase;
   padding: 0.75rem 1.5rem;
+  max-width: 100%;
+  white-space: initial;
+  word-wrap: break-word;
   transition: border-color 0.3s ease,
               background-color 0.3s ease,
               color 0.3s ease;


### PR DESCRIPTION
Long, non-wrapping text within buttons made the page scroll horizontally on small screens (like smartphones). Setting max-width, white-space, and word-wrap prevents this from happening no matter what the text is within a button.