### PR TITLE
Add BoD contact link; remove Transition Group para

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
           <div class='row'>
             <div class='col-lg-4'>
               <div class='card'>
-                <img class='card-img-top' src='/images/adam-savage.png' alt='Profile picture of Adam Savage'>
+                <img class='card-img-top' src='images/adam-savage.png' alt='Profile picture of Adam Savage'>
                 <div class='card-block'>
                   <h4 class='card-title'>Adam Savage</h4>
                   <div class='card-text'>
@@ -178,7 +178,7 @@
             </div>
             <div class='col-lg-4'>
               <div class='card'>
-                <img class='card-img-top' src='/images/harley-dubois.jpg' alt='Profile picture of Harley K. Dubois'>
+                <img class='card-img-top' src='images/harley-dubois.jpg' alt='Profile picture of Harley K. Dubois'>
                 <div class='card-block'>
                   <h4 class='card-title'>Harley K. Dubois</h4>
                   <div class='card-text'>
@@ -191,7 +191,7 @@
             </div>
             <div class='col-lg-4'>
               <div class='card'>
-                <img class='card-img-top' src='/images/pamela-jennings.png' alt='Profile picture of Pamela L. Jennings'>
+                <img class='card-img-top' src='images/pamela-jennings.png' alt='Profile picture of Pamela L. Jennings'>
                 <div class='card-block'>
                   <h4 class='card-title'>Pamela L. Jennings</h4>
                   <div class='card-text'>
@@ -206,7 +206,7 @@
           <div class='row'>
             <div class='col-lg-4 offset-lg-4'>
               <div class='card'>
-                <img class='card-img-top' src='/images/stephanie.jpg' alt='Profile picture of Stephanie Santoso'>
+                <img class='card-img-top' src='images/stephanie.jpg' alt='Profile picture of Stephanie Santoso'>
                 <div class='card-block'>
                   <h4 class='card-title'>Stephanie Santoso</h4>
                   <div class='card-text'>

--- a/index.html
+++ b/index.html
@@ -157,6 +157,12 @@
         <section class='container'>
           <h2>Board of Directors</h2>
           <div class='row'>
+            <p class='text-sm-center'>
+              Contact the Board of Directors<br />
+              <a href='mailto:info@nationofmakers.us' class='btn btn-lg btn-primary'>info@nationofmakers.us</a>
+            </p>
+          </div>
+          <div class='row'>
             <div class='col-lg-4'>
               <div class='card'>
                 <img class='card-img-top' src='/images/adam-savage.png' alt='Profile picture of Adam Savage'>
@@ -214,30 +220,6 @@
           </div>
         </section>
       </div>
-
-      <section class='page-section'>
-        <div class='container container-alt'>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>The Transition Group</h2>
-              <p>
-                The <strong>Transition Group</strong> is a collection of community members tasked with the details regarding the formation of the 
-                Nation of Makers nonprofit organization. This group has helped to structure and push forward the formation of the Mission, Vision, and Values 
-                of the new organization with direct community input. The Transition Group is also laying the framework for the organization including finding the
-                initial four <a href='#board'>Board Members</a>, forming the legal entity, organizing community elections for three Board of Directors seats, 
-                building a pool of additional qualified candidates willing to serve as board members, and facilitating a call for Executive Director candidates.
-              </p>
-              <p>
-                Together with many from the maker community the Transition Group has helped kickstart the Nation of Makers nonprofit. 
-                Learn more about the <a href='/about/#transition-group'>Transition Group</a>.
-              </p>
-              <p class='text-sm-center'>
-                <a href='mailto:nomtransitiongroup@gmail.com' class='btn btn-lg btn-primary'><i class='fa fa-envelope-o'></i> Contact the Transition Group!</a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
 
       <section class='page-section page-section-highlight' id='newsletter'>
         <div class='container'>

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
           <h2>Board of Directors</h2>
           <div class='row' style='padding-bottom:30px;'>
             <p class='text-sm-center'>
-              Contact the Board of Directors<br />
+              Contact the Nation of Makers<br />
               <a href='mailto:info@nationofmakers.us' class='btn btn-lg btn-primary'>info@nationofmakers.us</a>
             </p>
           </div>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       <div class='page-section' id='board'>
         <section class='container'>
           <h2>Board of Directors</h2>
-          <div class='row'>
+          <div class='row' style='padding-bottom:30px;'>
             <p class='text-sm-center'>
               Contact the Board of Directors<br />
               <a href='mailto:info@nationofmakers.us' class='btn btn-lg btn-primary'>info@nationofmakers.us</a>


### PR DESCRIPTION
This change will:
- remove the Transition Group paragraph. 
- add an email link to contact the BoD via info@nationofmakers.us
- The Transition Group para is not added back in because it's included in `about/index.html` already. I've included a screengrab of the about page attached below.

Board of Directors Section now looks like:
![image](https://cloud.githubusercontent.com/assets/305332/24937761/e44eaf88-1f00-11e7-9bbc-a217b9bc7f3d.png)

About page looks like:
![image](https://cloud.githubusercontent.com/assets/305332/24937782/0b22e84a-1f01-11e7-93f6-b9bf5403bb3a.png)