### PR TITLE
Contact email moved from the board section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,273 +1,185 @@
 <!doctype html>
 <html lang='en'>
-  <head>
-    <title>Nation of Makers - Helping Makers Through Supporting Maker Organizations</title>
-    <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>
-    <meta charset='UTF-8'>
-    <meta name='description' content='A national nonprofit organization dedicated to helping makers by supporting maker organizations. Get involved today!'>
-    <link href='https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css' rel='stylesheet'>
-    <link href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
-    <link href='https://fonts.googleapis.com/css?family=Crimson+Text%7COpen+Sans:400,700' rel='stylesheet'>
-    <link href='styles.css' rel='stylesheet'>
-    <script src='https://use.fontawesome.com/0ace9e8c28.js'></script>
-  </head>
-  <body>
+<head>
+<title>Nation of Makers - Helping Makers Through Supporting Maker Organizations</title>
+<meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>
+<meta charset='UTF-8'>
+<meta name='description' content='A national nonprofit organization dedicated to helping makers by supporting maker organizations. Get involved today!'>
+<link href='https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css' rel='stylesheet'>
+<link href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css?family=Crimson+Text%7COpen+Sans:400,700' rel='stylesheet'>
+<link href='styles.css' rel='stylesheet'>
+<script src='https://use.fontawesome.com/0ace9e8c28.js'></script>
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    <nav class='navbar navbar-light bg-faded'>
-      <div class='container'>
-        <a class='navbar-brand' href='/'>Nation of Makers</a>
-        <a class='btn btn-outline-primary float-sm-right' href='#newsletter' role='button'>Get Involved</a>
-      </div>
-    </nav>
+ga('create', 'UA-87332256-1', 'auto');
+ga('send', 'pageview');
+</script>
+</head>
+<body>
 
-    <div class='jumbotron homepage-jumbotron'>
-      <div class='container'>
-        <div class='row'>
-          <div class='col-lg-8 offset-lg-2'>
-            <h1 class='display-3'>Nation of Makers</h1>
-            <p class='lead'>
-              A nonprofit organization dedicated to helping makers by supporting maker organizations; through advocacy, 
-              the sharing of resources and the building of community within the maker movement and beyond.
-            </p>
-            <p class='lead'>
-              <a class='btn btn-primary btn-lg' href='#newsletter' role='button'>Get Involved <i class='fa fa-arrow-down'></i></a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
+<nav class='navbar navbar-light bg-faded'>
+	<div class='container'>
+		<a class='navbar-brand' href='/'>Nation of Makers</a>
+		<a class='btn btn-outline-primary float-sm-right' href='#newsletter' role='button'>Get Involved</a>
+	</div>
+</nav>
 
-    <div class='page-sections'>
+<div class='jumbotron homepage-jumbotron'>
+	<div class='container'>
+		<div class='row'>
+			<div class='col-lg-8 offset-lg-2'>
+				<h1 class='display-3'>Nation of Makers</h1>
+				<p class='lead'>A nonprofit organization dedicated to helping makers by supporting maker organizations; through advocacy, the sharing of resources and the building of community within the maker movement and beyond.</p>
+				<p class='lead'><a class='btn btn-primary btn-lg' href='#newsletter' role='button'>Get Involved <i class='fa fa-arrow-down'></i></a></p>
+			</div>
+		</div>
+	</div>
+</div>
 
-      <div class='page-section'>
-        <section class='container'>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Welcome to Nation of Makers</h2>
-              <iframe width='700' height='450' src='https://www.youtube.com/embed/AfcfPGVl_sM?rel=0' allowfullscreen style='width: 100%; border:0' class='mb-2'></iframe>
-              <p>
-                Let our <a href='#board'>board member</a> Adam Savage (MythBusters, Tested.com), tell you why Nation of Makers is so exciting!
-              </p>
-            <p class='text-xs-center'>
-              <a class='btn btn-primary btn-lg' href='/assets/nom-press-release.pdf' download role='button'>Download Our Press Release <i class='fa fa-download'></i></a>
-            </p>
-            </div>
-          </div>
-        </section>
-      </div>
+<div class='page-sections'>
 
-      <div class='page-section'>
-        <section class='container'>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>What is Nation of Makers?</h2>
-              <p>
-                Born of the human desire to create, innovate, and re-imagine the world around us, and fueled by the development of
-                low-cost tools, technologies and platforms that allow for more rapid and efficient designing, prototyping and
-                fabrication, the maker movement has enabled students and adults alike to bring their ideas to life. The maker
-                movement starts with the community; the ecosystem of makers and all that they do and create. More and
-                more, we are seeing makers take on challenges both locally and globally, using their knowledge and skills to improve
-                their lives and the lives of others in their communities.
-              </p>
-              <p>
-                Since the recent birth of the maker movement, millions of individuals, and thousands of organizations and institutions 
-                have found ways to explore their own creative potential. Over the past year alone, groups such as The Maker City project 
-                (supported by the Kauffman Foundation) have documented how the maker movement is having an impact on communities large 
-                and small across the U.S.; more than 1,500 K-12 schools in 50 states have signed on to the Maker Promise, co-led Maker Ed 
-                and Digital Promise, and over 77 colleges and universities made public new commitments to creating more opportunities for 
-                making on their campuses and in their communities. These are just a few of the recent examples of ways countless organizations
-                have been inspired by the hacker and makerspaces and maker events that exist all across this country.
-              </p> 
-              <p>
-                But there is still much work to be done. The maker movement has significant implications for manufacturing, economic and 
-                workforce development, education, healthcare innovation, community revitalization, and technology advancements. 
-                <strong>To continue to grow the coalition of diverse organizations that are working to support the maker community, this new independent, 
-                  non-profit organization called Nation of Makers has been formed. We commit to serving and representing the full variety of spaces, 
-                  events, and institutions serving makers, including non-profit organizations, museums, libraries, science centers, educational 
-                  institutions, foundations and for-profit companies.</strong>
-              </p>
-              <p>
-                Nation of Makers is working with leaders from the maker community in all 50 states and has received more than 300 Letters of Support 
-                from hackerspaces, makerspaces, companies, libraries, local government, and economic development agencies. These Letters of Support 
-                both strengthen the organization and share some of the amazing work already being done. We invite you to read some of these stories.
-              </p>
+	<div class='page-section'>
+		<section class='container'>
+			<div class='row'>
+				<div class='col-lg-8 offset-lg-2'>
+					<h2>Welcome to Nation of Makers</h2>
+					<iframe width='700' height='450' src='https://www.youtube.com/embed/AfcfPGVl_sM?rel=0' allowfullscreen style='width: 100%; border:0' class='mb-2'></iframe>
+					<p>Let our <a href='#board'>board member</a> Adam Savage (MythBusters, Tested.com), tell you why Nation of Makers is so exciting!</p>
+					<p class='text-xs-center'><a class='btn btn-primary btn-lg' href='/assets/nom-press-release.pdf' download role='button'>Download Our Press Release <i class='fa fa-download'></i></a></p>
+				</div>
+			</div>
+		</section>
+	</div>
 
-              <p class='text-xs-center'>
-                <a class='btn btn-primary btn-lg' href='http://bit.ly/nom-support-letters' target='_blank' role='button'>Read our Letters of Support <i class='fa fa-external-link'></i></a>
-              </p>
-            </div>
-          </div>
-        </section>
-      </div>
+	<div class='page-section'>
+		<section class='container'>
+			<div class='row'>
+				<div class='col-lg-8 offset-lg-2'>
+					<h2>What is Nation of Makers?</h2>
+					<p>Born of the human desire to create, innovate, and re-imagine the world around us, and fueled by the development of low-cost tools, technologies and platforms that allow for more rapid and efficient designing, prototyping and fabrication, the maker movement has enabled students and adults alike to bring their ideas to life. The maker movement starts with the community; the ecosystem of makers and all that they do and create. More and more, we are seeing makers take on challenges both locally and globally, using their knowledge and skills to improve their lives and the lives of others in their communities.</p>
+					<p>Since the recent birth of the maker movement, millions of individuals, and thousands of organizations and institutions have found ways to explore their own creative potential. Over the past year alone, groups such as The Maker City project (supported by the Kauffman Foundation) have documented how the maker movement is having an impact on communities large and small across the U.S.; more than 1,500 K-12 schools in 50 states have signed on to the Maker Promise, co-led Maker Ed and Digital Promise, and over 77 colleges and universities made public new commitments to creating more opportunities for making on their campuses and in their communities. These are just a few of the recent examples of ways countless organizations have been inspired by the hacker and makerspaces and maker events that exist all across this country.</p> 
+					<p>But there is still much work to be done. The maker movement has significant implications for manufacturing, economic and workforce development, education, healthcare innovation, community revitalization, and technology advancements. <strong>To continue to grow the coalition of diverse organizations that are working to support the maker community, this new independent, non-profit organization called Nation of Makers has been formed. We commit to serving and representing the full variety of spaces, events, and institutions serving makers, including non-profit organizations, museums, libraries, science centers, educational institutions, foundations and for-profit companies.</strong></p>
+					<p>Nation of Makers is working with leaders from the maker community in all 50 states and has received more than 300 Letters of Support from hackerspaces, makerspaces, companies, libraries, local government, and economic development agencies. These Letters of Support both strengthen the organization and share some of the amazing work already being done. We invite you to read some of these stories.</p>
+					<p class='text-xs-center'><a class='btn btn-primary btn-lg' href='http://bit.ly/nom-support-letters' target='_blank' role='button'>Read our Letters of Support <i class='fa fa-external-link'></i></a></p>
+				</div>
+			</div>
+		</section>
+	</div>
 
-      <div class='page-section'>
-        <section class='container'>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Mission</h2>
-              <p>We support the full range of organizations that impact makers by encouraging connections, broadly sharing resources, facilitating funding opportunities, engaging in policy development, and advocating for the maker movement. We help maker organizations amplify the passion, innovation, creativity, and diversity of the maker community, to maximize both local and global impact.</p>
-            </div>
-          </div>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Vision</h2>
-              <p>
-                The vision of Nation of Makers is to build a society where everyone has access to the tools, technologies, experiences
-                and knowledge to make anything; to create a thriving, connected, and inclusive community of practice where
-                collaboration fosters a culture of abundance.
-              </p>
-              <p>
-                Below are some <i>examples</i> of the initiatives that this organization <i>could</i> lead. These activities correspond to key needs
-                identified by the maker community and those organizations who are currently supporting the community:
-              </p>
-              <ul>
-                <li>
-                  <strong>Sharing best practices</strong> - Gathering information and best practices from the maker community about starting
-                  and sustaining makerspaces and maker events to create a centralized location and resource library where
-                  these can be openly accessible.
-                </li>
-                <li>
-                  <strong>Advocating for the interests of the maker community</strong> – Participating in critical policy development processes
-                  impacting the maker community at the federal, state or local level. This can also take shape as key
-                  stakeholders across different sectors (government, academia, industry) are convened with the maker
-                  community, to identify and collectively develop ways to address key needs.
-                </li>
-                <li>
-                  <strong>Facilitating funding and non-monetary resource opportunities</strong> - Making it easier for maker spaces and other
-                  maker organizations to secure funding by identifying existing opportunities, collaborating with funders to
-                  develop new grant opportunities, and connecting supporters who may have non-monetary resources to the
-                  organizations who need them.
-                </li>
-                <li>
-                  <strong>Launching a maker fellows program</strong> - Launching a program that aims to place makers with unique skills and
-                  experiences within organizations such as federal agencies, companies and research institutions to work on
-                  specific projects and inspire a culture of making within organizations.
-                </li>
-                <li>
-                  <strong>Broadening access and increasing diversity</strong> - Creating and implementing a strategy for 
-                  broadening access to making for underrepresented groups and underserved communities.
-                </li>
-              </ul>
-            </div>
-          </div>
-        </section>
-      </div>
+	<div class='page-section'>
+		<section class='container'>
+			<div class='row'>
+				<div class='col-lg-8 offset-lg-2'>
+					<h2>Mission</h2>
+					<p>We support the full range of organizations that impact makers by encouraging connections, broadly sharing resources, facilitating funding opportunities, engaging in policy development, and advocating for the maker movement. We help maker organizations amplify the passion, innovation, creativity, and diversity of the maker community, to maximize both local and global impact.</p>
+				</div>
+			</div>
+		<div class='row'>
+			<div class='col-lg-8 offset-lg-2'>
+				<h2>Vision</h2>
+				<p>The vision of Nation of Makers is to build a society where everyone has access to the tools, technologies, experiences and knowledge to make anything; to create a thriving, connected, and inclusive community of practice where collaboration fosters a culture of abundance.</p>
+				<p>Below are some <i>examples</i> of the initiatives that this organization <i>could</i> lead. These activities correspond to key needs identified by the maker community and those organizations who are currently supporting the community:</p>
+					<ul>
+						<li><strong>Sharing best practices</strong> - Gathering information and best practices from the maker community about starting and sustaining makerspaces and maker events to create a centralized location and resource library where these can be openly accessible.</li>
+						<li><strong>Advocating for the interests of the maker community</strong> – Participating in critical policy development processes impacting the maker community at the federal, state or local level. This can also take shape as key stakeholders across different sectors (government, academia, industry) are convened with the maker community, to identify and collectively develop ways to address key needs.</li>
+						<li><strong>Facilitating funding and non-monetary resource opportunities</strong> - Making it easier for maker spaces and other maker organizations to secure funding by identifying existing opportunities, collaborating with funders to develop new grant opportunities, and connecting supporters who may have non-monetary resources to the organizations who need them.</li>
+						<li><strong>Launching a maker fellows program</strong> - Launching a program that aims to place makers with unique skills and experiences within organizations such as federal agencies, companies and research institutions to work on specific projects and inspire a culture of making within organizations.</li>
+						<li><strong>Broadening access and increasing diversity</strong> - Creating and implementing a strategy for broadening access to making for underrepresented groups and underserved communities.</li>
+					</ul>
+				</div>
+			</div>
+		</section>
+	</div>
 
-      <div class='page-section' id='board'>
-        <section class='container'>
-          <h2>Board of Directors</h2>
-          <div class='row' style='padding-bottom:30px;'>
-            <p class='text-sm-center'>
-              Contact the Nation of Makers<br />
-              <a href='mailto:info@nationofmakers.us' class='btn btn-lg btn-primary'>info@nationofmakers.us</a>
-            </p>
-          </div>
-          <div class='row'>
-            <div class='col-lg-4'>
-              <div class='card'>
-                <img class='card-img-top' src='images/adam-savage.png' alt='Profile picture of Adam Savage'>
-                <div class='card-block'>
-                  <h4 class='card-title'>Adam Savage</h4>
-                  <div class='card-text'>
-                    <p>
-                      Head of Tested.com and past co-host of Discovery Channel television series MythBusters.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class='col-lg-4'>
-              <div class='card'>
-                <img class='card-img-top' src='images/harley-dubois.jpg' alt='Profile picture of Harley K. Dubois'>
-                <div class='card-block'>
-                  <h4 class='card-title'>Harley K. Dubois</h4>
-                  <div class='card-text'>
-                    <p>
-                      Co-founder of Burning Man and founding member of the Black Rock Arts Foundation (BRAF).
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class='col-lg-4'>
-              <div class='card'>
-                <img class='card-img-top' src='images/pamela-jennings.png' alt='Profile picture of Pamela L. Jennings'>
-                <div class='card-block'>
-                  <h4 class='card-title'>Pamela L. Jennings</h4>
-                  <div class='card-text'>
-                    <p>
-                      Professor for Innovation and Entrepreneurship at Winston-Salem State University.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class='row'>
-            <div class='col-lg-4 offset-lg-4'>
-              <div class='card'>
-                <img class='card-img-top' src='images/stephanie.jpg' alt='Profile picture of Stephanie Santoso'>
-                <div class='card-block'>
-                  <h4 class='card-title'>Stephanie Santoso</h4>
-                  <div class='card-text'>
-                    <p>
-                      Former White House Senior Advisor for Making.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
+	<div class='page-section' id='board'>
+		<section class='container'>
+			<h2>Board of Directors</h2>
+			<div class='row'>
+				<div class='col-lg-4'>
+					<div class='card'>
+						<img class='card-img-top' src='images/adam-savage.png' alt='Profile picture of Adam Savage'>
+						<div class='card-block'>
+							<h4 class='card-title'>Adam Savage</h4>
+							<div class='card-text'>
+								<p>Head of Tested.com and past co-host of Discovery Channel television series MythBusters.</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			<div class='col-lg-4'>
+				<div class='card'>
+					<img class='card-img-top' src='images/harley-dubois.jpg' alt='Profile picture of Harley K. Dubois'>
+					<div class='card-block'>
+						<h4 class='card-title'>Harley K. Dubois</h4>
+						<div class='card-text'>
+							<p>Co-founder of Burning Man and founding member of the Black Rock Arts Foundation (BRAF).</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class='col-lg-4'>
+				<div class='card'>
+					<img class='card-img-top' src='images/pamela-jennings.png' alt='Profile picture of Pamela L. Jennings'>
+					<div class='card-block'>
+						<h4 class='card-title'>Pamela L. Jennings</h4>
+						<div class='card-text'>
+							<p>Professor for Innovation and Entrepreneurship at Winston-Salem State University.</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			</div>
+			<div class='row'>
+				<div class='col-lg-4 offset-lg-4'>
+					<div class='card'>
+						<img class='card-img-top' src='images/stephanie.jpg' alt='Profile picture of Stephanie Santoso'>
+						<div class='card-block'>
+							<h4 class='card-title'>Stephanie Santoso</h4>
+							<div class='card-text'>
+								<p>Former White House Senior Advisor for Making.</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	</div>
 
-      <section class='page-section page-section-highlight' id='newsletter'>
-        <div class='container'>
-          <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Stay Tuned!</h2>
-              <p>
-                <strong>Want to stay up to date with Nation of Makers progress?</strong>
-                We're just getting started, so stay tuned via our email newsletter for updates on organizational progress, membership information and a whole lot more!
-              </p>
-              <p class='text-xs-center'>
-                <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
+	<section class='page-section page-section-highlight' id='newsletter'>
+		<div class='container'>
+			<div class='row'>
+				<div class='col-lg-8 offset-lg-2'>
+					<h2>Stay Tuned!</h2>
+					<p><strong>Want to stay up to date with Nation of Makers progress?</strong> We're just getting started, so stay tuned via our email newsletter for updates on organizational progress, membership information and a whole lot more!</p>
+					<p class='text-xs-center'><a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a></p>
+				</div>
+			</div>
+			<div class='row' style='padding-bottom:30px;'>
+				<p class='text-sm-center'>
+					Contact the Nation of Makers<br />
+					<a href='mailto:info@nationofmakers.us'>info@nationofmakers.us</a>
+				</p>
+			</div>
+		</div>
+	</section>
 
-    </div><!-- end: page-sections -->
+</div><!-- end: page-sections -->
 
-    <footer class='page-footer'>
-      <div class='container'>
-        <div class='float-xs-right'>
-          <a href='https://github.com/nationofmakers/nationofmakers.github.io' target='_blank'><i class='fa fa-github fa-3x'></i></a>
-        </div>
-        <p>
-          <strong>Made with <i class='fa fa-heart'></i> on planet Earth</strong>,
-          see all our <a href='https://github.com/nationofmakers/nationofmakers.github.io/graphs/contributors'>contributors</a>.
-        </p>
-        <p>
-          110 University Blvd #752, Silver Spring, MD 20918
-        </p>
-        <p>
-          Copyright &copy; 2016 Nation of Makers
-        </p>
-      </div>
-    </footer>
+<footer class='page-footer'>
+	<div class='container'>
+		<div class='float-xs-right'>
+			<a href='https://github.com/nationofmakers/nationofmakers.github.io' target='_blank'><i class='fa fa-github fa-3x'></i></a>
+		</div>
+		<p><strong>Made with <i class='fa fa-heart'></i> on planet Earth</strong>, see all our <a href='https://github.com/nationofmakers/nationofmakers.github.io/graphs/contributors'>contributors</a>.</p>
+		<p>110 University Blvd #752, Silver Spring, MD 20918</p>
+		<p>Copyright &copy; 2017 Nation of Makers</p>
+	</div>
+</footer>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-87332256-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-
-  </body>
+</body>
 </html>


### PR DESCRIPTION
Contact email moved from the board section to the "Stay in Touch" section to prevent people from thinking they can directly contact members of the board via the NoM email address.