### PR TITLE
Moved email link from board to "Stay Tuned"

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,12 +156,6 @@
       <div class='page-section' id='board'>
         <section class='container'>
           <h2>Board of Directors</h2>
-          <div class='row' style='padding-bottom:30px;'>
-            <p class='text-sm-center'>
-              Contact the Nation of Makers<br />
-              <a href='mailto:info@nationofmakers.us' class='btn btn-lg btn-primary'>info@nationofmakers.us</a>
-            </p>
-          </div>
           <div class='row'>
             <div class='col-lg-4'>
               <div class='card'>
@@ -232,6 +226,12 @@
               </p>
               <p class='text-xs-center'>
                 <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
+              </p>
+            </div>
+            <div class='row' style='padding-bottom:30px;'>
+              <p class='text-sm-center'>
+                Contact the Nation of Makers<br />
+                <a href='mailto:info@nationofmakers.us'>info@nationofmakers.us</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Users were writing to the email address thinking it was delivered directly to the board, so it's been moved further down on the page.

Users were also unable to copy the email address to their clipboard due to the bootstrap styles.  The styles have been removed.

