### PR TITLE
Move 'Contact Nation of Makers' to below newsletter button.

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,12 +236,12 @@
                 <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
               </p>
             </div>
-            <div class='row' style='padding-bottom:30px;'>
+          </div>
+          <div class='row' style='padding-bottom:30px;'>
               <p class='text-sm-center'>
                 Contact the Nation of Makers<br />
                 <a href='mailto:info@nationofmakers.us'>info@nationofmakers.us</a>
               </p>
-            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
This fixes the layout problem and follows bootstrap's intended functionality for rows.