### PR TITLE
[#88] Add Volunteer link to Get Involved sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
             <a class="nav-link" href="year_one.html">Year One</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#newsletter">Get Involved</a>
+            <a class="nav-link" href="#get-involved">Get Involved</a>
           </li>
           <li class="nav-item">
             <a class="nav-link active" href="#">About</a>
@@ -405,18 +405,34 @@
           </div>
       </section><!-- end: transition group -->
 
-      <section class='page-section page-section-highlight' id='newsletter'>
+      <section class='page-section page-section-highlight' id='get-involved'>
         <div class='container'>
           <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Stay Tuned!</h2>
-              <p>
-                <strong>Want to stay up to date with Nation of Makers progress?</strong>
-                We're just getting started, stay tuned via our email newsletter for updates on organizational progress, membership information and a whole lot more!
-              </p>
-              <p class='text-xs-center'>
-                <a href='http://bit.ly/nom-newsletter' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
-              </p>
+            <h2>Get Involved</h2>
+            <div class='col-lg-6'>
+              <h3>Subscribe</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Want to stay up to date with Nation of Makers?</strong>
+                  Stay tuned via our email newsletter for updates, progress, membership information and more!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
+                </p>
+              </div>
+            </div>
+
+            <div class='col-lg-6'>
+              <h3>Volunteer</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Have a passion for Making?</strong>
+                  We're looking for motivated individuals to help drive the mission of Nation of Makers forward. Request information about joining!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='https://docs.google.com/forms/d/e/1FAIpQLSd9ua9baUOYVC30VOdK0-iCczc7QMufVSPK_btDiDcjR7y0ew/viewform?usp=sf_link' target='_blank' class='btn btn-lg btn-primary'>Volunteer Signup →</a>
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/faq.md
+++ b/faq.md
@@ -5,6 +5,9 @@
 
 Please join our [newsletter](http://bit.ly/nom-newsletter).
 
+Or register your [interest in
+volunteering](https://docs.google.com/a/deliverydudes.com/forms/d/e/1FAIpQLSd9ua9baUOYVC30VOdK0-iCczc7QMufVSPK_btDiDcjR7y0ew/viewform).
+
 More details about membership and other details will be coming soon!
 
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <a class="nav-link" href="year_one.html">Year One</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#newsletter">Get Involved</a>
+            <a class="nav-link" href="#get-involved">Get Involved</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="about.html">About</a>
@@ -51,7 +51,7 @@
               the sharing of resources and the building of community within the maker movement and beyond.
             </p>
             <p class='lead'>
-              <a class='btn btn-primary btn-lg' href='#newsletter' role='button'>Get Involved <i class='fa fa-arrow-down'></i></a>
+              <a class='btn btn-primary btn-lg' href='#get-involved' role='button'>Get Involved <i class='fa fa-arrow-down'></i></a>
             </p>
           </div>
         </div>
@@ -281,25 +281,35 @@
         </section>
       </div>
 
-      <section class='page-section page-section-highlight' id='newsletter'>
+      <section class='page-section page-section-highlight' id='get-involved'>
         <div class='container'>
           <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Stay Tuned!</h2>
-              <p>
-                <strong>Want to stay up to date with Nation of Makers progress?</strong>
-                We're just getting started, so stay tuned via our email newsletter for updates on organizational progress, membership information and a whole lot more!
-              </p>
-              <p class='text-xs-center'>
-                <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
-              </p>
+            <h2>Get Involved</h2>
+            <div class='col-lg-6'>
+              <h3>Subscribe</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Want to stay up to date with Nation of Makers?</strong>
+                  Stay tuned via our email newsletter for updates, progress, membership information and more!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class='row' style='padding-bottom:30px;'>
-              <p class='text-xs-center'>
-                Contact the Nation of Makers<br />
-                <a href='mailto:info@nationofmakers.us'>info@nationofmakers.us</a>
-              </p>
+
+            <div class='col-lg-6'>
+              <h3>Volunteer</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Have a passion for Making?</strong>
+                  We're looking for motivated individuals to help drive the mission of Nation of Makers forward. Request information about joining!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='https://docs.google.com/forms/d/e/1FAIpQLSd9ua9baUOYVC30VOdK0-iCczc7QMufVSPK_btDiDcjR7y0ew/viewform?usp=sf_link' target='_blank' class='btn btn-lg btn-primary'>Volunteer Signup →</a>
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,17 @@ h3 {
   margin: 1rem 0;
   text-align: left;
 }
+#get-involved h3 {
+  color: black;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin: 1rem 0;
+  text-align: center;
+}
+#get-involved .col-lg-6 {
+  padding: 1rem;
+}
 
 a {
   color: #01b5a6;

--- a/year_one.html
+++ b/year_one.html
@@ -32,7 +32,7 @@
             <a class="nav-link active" href="#">Year One</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#newsletter">Get Involved</a>
+            <a class="nav-link" href="#get-involved">Get Involved</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="about.html">About</a>
@@ -126,25 +126,35 @@
         </div>
       </section>
 
-      <section class='page-section page-section-highlight' id='newsletter'>
+      <section class='page-section page-section-highlight' id='get-involved'>
         <div class='container'>
           <div class='row'>
-            <div class='col-lg-8 offset-lg-2'>
-              <h2>Stay Tuned!</h2>
-              <p>
-                <strong>Want to stay up to date with Nation of Makers progress?</strong>
-                We're just getting started, so stay tuned via our email newsletter for updates on organizational progress, membership information and a whole lot more!
-              </p>
-              <p class='text-xs-center'>
-                <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
-              </p>
+            <h2>Get Involved</h2>
+            <div class='col-lg-6'>
+              <h3>Subscribe</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Want to stay up to date with Nation of Makers?</strong>
+                  Stay tuned via our email newsletter for updates, progress, membership information and more!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='http://bit.ly/nom-newsletter' target='_blank' class='btn btn-lg btn-primary'>Join the Newsletter →</a>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class='row' style='padding-bottom:30px;'>
-              <p class='text-xs-center'>
-                Contact the Nation of Makers<br />
-                <a href='mailto:info@nationofmakers.us'>info@nationofmakers.us</a>
-              </p>
+
+            <div class='col-lg-6'>
+              <h3>Volunteer</h3>
+              <div>
+                <p class='text-xs-center'>
+                  <strong>Have a passion for Making?</strong>
+                  We're looking for motivated individuals to help drive the mission of Nation of Makers forward. Request information about joining!
+                </p>
+                <p class='text-xs-center'>
+                  <a href='https://docs.google.com/forms/d/e/1FAIpQLSd9ua9baUOYVC30VOdK0-iCczc7QMufVSPK_btDiDcjR7y0ew/viewform?usp=sf_link' target='_blank' class='btn btn-lg btn-primary'>Volunteer Signup →</a>
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Here's what the Get Involved section looks like on each page:

<img width="626" alt="nation_of_makers_-_helping_makers_through_supporting_maker_organizations" src="https://cloud.githubusercontent.com/assets/305332/25566134/a0b1be00-2da1-11e7-917b-b37369e23410.png">

Both buttons open new windows.